### PR TITLE
Updating Selenium 42 to 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ultra-easy acceptance testing for your Meteor app with Selenium and Nightwatch.
 ####  Requirements
 
   - Meteor
-  - [Firefox 31](https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/31.0/) (Firefox 33+ won't work)  
+  - [Firefox 31](https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/31.0/) (Firefox 33+ won't work)  NOTE: recent update to selenium-server-standalone-2.42.0.jar may work with Firefox 33+
   - [Java for OSX](http://support.apple.com/kb/DL1572)  
 
 ####  Size Warning!
@@ -92,7 +92,7 @@ If the above gives you any trouble, it may be because the ``meteor`` command is 
 # run_nightwatch.sh
 #echo "changing file permissions"
 chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/launch_nightwatch*.sh
-chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.42.0.jar
+chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar
 
 #echo "installing nightwatch in .meteor/local/build"
   cd .meteor/local/build

--- a/launch_nightwatch_from_app_root.sh
+++ b/launch_nightwatch_from_app_root.sh
@@ -3,7 +3,7 @@
 #
 # echo "changing file permissions"
 # chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/launch_nightwatch*.sh
-# chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.42.0.jar
+# chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar
 #
 # echo "installing nightwatch in .meteor/local/build"
 #   cd .meteor/local/build
@@ -33,7 +33,7 @@ echo "Setting variables..."
 #set -e
 
 # defaults
-CONFIG=".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/nightwatch_from_app_root.json"
+CONFIG="packages/clinical_nightwatch/nightwatch_from_app_root.json"
 ENVIRONMENT="default"
 _TESTS=""
 _GROUP=""
@@ -137,9 +137,9 @@ done
 
 echo "Changing file permissions..."
 # Setup: changing file permissions"
-mkdir -p .meteor/local/build/programs/server/assets/packages/clinical_nightwatch
-chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/launch_nightwatch*.sh
-chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.42.0.jar
+#mkdir -p .meteor/local/build/programs/server/assets/packages/clinical_nightwatch
+#chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/launch_nightwatch*.sh
+#chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar
 mkdir -p tests/logs
 chmod 0777 tests/logs
 

--- a/launch_nightwatch_from_app_root.sh
+++ b/launch_nightwatch_from_app_root.sh
@@ -33,7 +33,7 @@ echo "Setting variables..."
 #set -e
 
 # defaults
-CONFIG="packages/clinical_nightwatch/nightwatch_from_app_root.json"
+CONFIG=".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/nightwatch_from_app_root.json"
 ENVIRONMENT="default"
 _TESTS=""
 _GROUP=""
@@ -137,9 +137,9 @@ done
 
 echo "Changing file permissions..."
 # Setup: changing file permissions"
-#mkdir -p .meteor/local/build/programs/server/assets/packages/clinical_nightwatch
-#chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/launch_nightwatch*.sh
-#chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar
+mkdir -p .meteor/local/build/programs/server/assets/packages/clinical_nightwatch
+chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/launch_nightwatch*.sh
+chmod +x .meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar
 mkdir -p tests/logs
 chmod 0777 tests/logs
 

--- a/nightwatch_from_app_root.json
+++ b/nightwatch_from_app_root.json
@@ -6,7 +6,7 @@
   "globals_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/globals.json",
 
   "selenium" : {
-    "start_process" : false,
+    "start_process" : true,
     "server_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
     "log_path" : "logs",
     "host" : "127.0.0.1",

--- a/nightwatch_from_app_root.json
+++ b/nightwatch_from_app_root.json
@@ -3,11 +3,11 @@
   "output_folder" : "tests/.reports/nightwatch-acceptance",
   "custom_commands_path" : "",
   "custom_assertions_path" : "",
-  "globals_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/globals.json",
+  "globals_path" : "packages/clinical_nightwatch/globals.json",
 
   "selenium" : {
-    "start_process" : true,
-    "server_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.42.0.jar",
+    "start_process" : false,
+    "server_path" : "packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
     "log_path" : "logs",
     "host" : "127.0.0.1",
     "port" : 4444,

--- a/nightwatch_from_app_root.json
+++ b/nightwatch_from_app_root.json
@@ -3,11 +3,11 @@
   "output_folder" : "tests/.reports/nightwatch-acceptance",
   "custom_commands_path" : "",
   "custom_assertions_path" : "",
-  "globals_path" : "packages/clinical_nightwatch/globals.json",
+  "globals_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/globals.json",
 
   "selenium" : {
     "start_process" : false,
-    "server_path" : "packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
+    "server_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
     "log_path" : "logs",
     "host" : "127.0.0.1",
     "port" : 4444,

--- a/nightwatch_from_app_root_with_saucelabs.json
+++ b/nightwatch_from_app_root_with_saucelabs.json
@@ -7,7 +7,7 @@
 
   "selenium" : {
     "start_process" : true,
-    "server_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.42.0.jar",
+    "server_path" : ".meteor/local/build/programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
     "log_path" : "logs",
     "host" : "127.0.0.1",
     "port" : 4444,

--- a/nightwatch_from_package.json
+++ b/nightwatch_from_package.json
@@ -3,11 +3,11 @@
   "output_folder" : "../../../tests/.reports/nightwatch-acceptance",
   "custom_commands_path" : "",
   "custom_assertions_path" : "",
-  "globals_path" : "packages/clinical_nightwatch/globals.json",
+  "globals_path" : "programs/server/assets/packages/clinical_nightwatch/globals.json",
 
   "selenium" : {
     "start_process" : true,
-    "server_path" : "packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
+    "server_path" : "programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
     "log_path" : "nightwatch-logs",
     "host" : "127.0.0.1",
     "port" : 4444,

--- a/nightwatch_from_package.json
+++ b/nightwatch_from_package.json
@@ -3,11 +3,11 @@
   "output_folder" : "../../../tests/.reports/nightwatch-acceptance",
   "custom_commands_path" : "",
   "custom_assertions_path" : "",
-  "globals_path" : "programs/server/assets/packages/clinical_nightwatch/globals.json",
+  "globals_path" : "packages/clinical_nightwatch/globals.json",
 
   "selenium" : {
     "start_process" : true,
-    "server_path" : "programs/server/assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.42.0.jar",
+    "server_path" : "packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
     "log_path" : "nightwatch-logs",
     "host" : "127.0.0.1",
     "port" : 4444,

--- a/nightwatch_from_velocity.json
+++ b/nightwatch_from_velocity.json
@@ -7,7 +7,7 @@
 
   "selenium" : {
     "start_process" : true,
-    "server_path" : "./assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.42.0.jar",
+    "server_path" : "./assets/packages/clinical_nightwatch/selenium/selenium-server-standalone-2.44.0.jar",
     "log_path" : "../../../../../tests/nightwatch/.logs",
     "host" : "127.0.0.1",
     "port" : 4444,

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Ultra-easy acceptance testing with Selenium.",
-  version: "1.5.1",
+  version: "1.5.2",
   name: "clinical:nightwatch",
   git: "https://github.com/awatson1978/clinical-nightwatch",
   debugOnly: true
@@ -24,7 +24,6 @@ Package.onUse(function(api) {
   api.addFiles('nightwatch_from_velocity.json', ['server']);
 
   api.addFiles('selenium/chromedriver', ['server']);
-  api.addFiles('selenium/selenium-server-standalone-2.42.0.jar', ['server']);
   api.addFiles('selenium/selenium-server-standalone-2.44.0.jar', ['server']);
 
 });

--- a/package.js
+++ b/package.js
@@ -25,6 +25,7 @@ Package.onUse(function(api) {
 
   api.addFiles('selenium/chromedriver', ['server']);
   api.addFiles('selenium/selenium-server-standalone-2.42.0.jar', ['server']);
+  api.addFiles('selenium/selenium-server-standalone-2.44.0.jar', ['server']);
 
 });
 


### PR DESCRIPTION
I updated selenium-server-standalone-2.42.0.jar to selenium-server-standalone-2.44.0.jar.  This should work with Firefox 33+
Please note I haven't done extensive testing.  I updated the files for Velocity and Sauce to use the new jar although I haven't tested them.  
I updated the package version from 1.5.1 to 1.5.2 as a convenience but please feel free to update the version as you see fit.